### PR TITLE
Revert "Bump ubuntu from 20.04 to 22.04"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ENV \
   DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Reverts camptocamp/python-action#81

Hope it should fix : https://github.com/camptocamp/ngeo/runs/6156732295?check_suite_focus=true

Note that I do not understand how the build with ubuntu 22.04 passed on CI as it fails locally on my workstation.