### PR TITLE
Add missing configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,9 @@ include_trailing_comma = true
 force_grid_wrap = false
 use_parentheses = true
 line_length = 110
+
+[tool.poetry]
+name = "python-action"
+version = "0.0.0"
+description = "Docker base image for GitHub Action that needs Python"
+authors = ["Camptocamp <info@camptocamp.com>"]


### PR DESCRIPTION
Needed to make `poetry --version` work, used in the audit.